### PR TITLE
Add possibility to use the module attribute `:endpoint` from test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,33 +28,35 @@ be found at [https://hexdocs.pm/test_dispatch_form](https://hexdocs.pm/test_disp
 
 ## Use
 
-`dispatch_form_with/3` will use the conn's `private.phoenix_endpoint` as endpoint
-to dispatch the form to. So if you have a test case where you set the default
-endpoint for testing with Phoenix, then you can define the endpoint for your tests
-there:
-
-```elixir
-defmodule MyApp.ConnCase do
-  use ExUnit.CaseTemplate
-
-  using do
-    quote do
-      # The default endpoint for testing
-      @endpoint MyApp.Endpoint
-    end
-  end
-end
-```
-
 Import TestDispatchForm in your test module or your test case and you can call
 `dispatch_form_with/3` from there.
 
+To use `dispatch_form_with/3` a request has to be made to a page where a form is
+present. The conn that is received will be parsed by the `dispatch_form_with/3`
+and the form will be dispatched with the attributes that are given or the
+default values when they are not given.
+
 ```elixir
-defmodule Project.Web.MyTest do
+defmodule MyAppWeb.MyTest do
+  use MyAppWeb.ConnCase
   import TestDispatchForm
 
-  test "dispatches form" do
-    TestDispatchForm.dispatch_form_with(conn, %{name: "John Doe", email: "john@doe.com"}, :user)
+  test "dispatches form with attributes and entity" do
+    conn = build_conn()
+
+    assert conn
+           |> get(Routes.user_path(conn, :new))
+           |> dispatch_form_with(%{name: "John Doe", email: "john@doe.com"}, :user)
+           |> redirected_to(Routes.user_path(conn, :index))
+  end
+
+  test "dispatches form with default values and test_selector" do
+    conn = build_conn()
+
+    assert conn
+           |> get(Routes.user_path(conn, :index))
+           |> dispatch_form_with(User.IndexView.test_selector("batch-action"))
+           |> html_response(200)
   end
 end
 ```
@@ -72,7 +74,7 @@ the form.
 If an entity is given, the params will be prepended by this entity. So for:
 
 ```elixir
-TestDispatchForm.dispatch_form_with(conn, %{name: "John Doe", email: "john@doe.com"}, :user)
+dispatch_form_with(conn, %{name: "John Doe", email: "john@doe.com"}, :user)
 ```
 
 this will result in the following params:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,31 @@ be found at [https://hexdocs.pm/test_dispatch_form](https://hexdocs.pm/test_disp
 
 ## Use
 
+`dispatch_form_with/3` will use the conn's `private.phoenix_endpoint` by default
+as endpoint to dispatch the form to. So if you have a test case where you set
+the default endpoint for testing with Phoenix, then you can define the endpoint
+for your tests there:
+
+```elixir
+defmodule MyApp.ConnCase do
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      # The default endpoint for testing
+      @endpoint MyApp.Endpoint
+    end
+  end
+end
+```
+
+You can also set the `:endpoint` in your config settings and this will override
+the use of the `conn.private.phoenix_endpoint` as endpoint:
+
+```elixir
+config :test_dispatch_form, :endpoint, MyApp.Endpoint
+```
+
 Import TestDispatchForm in your test module or your test case and you can call
 `dispatch_form_with/3` from there.
 
@@ -63,6 +88,6 @@ this will result in the following params:
 %{"user" => %{name: "John Doe", email: "john@doe.com"}}
 ```
 
-Ultimately, the conn is dispatched to the given endpoint using
-`Phoenix.ConnTest.dispatch/5`, with the params and with the method and action
-found in the form.
+Ultimately, the conn is dispatched to the either the application config
+`:endpoint` or the conn's endpoint using `Phoenix.ConnTest.dispatch/5`, with
+the params and with the method and action found in the form.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ be found at [https://hexdocs.pm/test_dispatch_form](https://hexdocs.pm/test_disp
 
 ## Use
 
-`dispatch_form_with/3` will use the conn's `private.phoenix_endpoint` by default
-as endpoint to dispatch the form to. So if you have a test case where you set
-the default endpoint for testing with Phoenix, then you can define the endpoint
-for your tests there:
+`dispatch_form_with/3` will use the conn's `private.phoenix_endpoint` as endpoint
+to dispatch the form to. So if you have a test case where you set the default
+endpoint for testing with Phoenix, then you can define the endpoint for your tests
+there:
 
 ```elixir
 defmodule MyApp.ConnCase do
@@ -44,13 +44,6 @@ defmodule MyApp.ConnCase do
     end
   end
 end
-```
-
-You can also set the `:endpoint` in your config settings and this will override
-the use of the `conn.private.phoenix_endpoint` as endpoint:
-
-```elixir
-config :test_dispatch_form, :endpoint, MyApp.Endpoint
 ```
 
 Import TestDispatchForm in your test module or your test case and you can call
@@ -88,6 +81,6 @@ this will result in the following params:
 %{"user" => %{name: "John Doe", email: "john@doe.com"}}
 ```
 
-Ultimately, the conn is dispatched to the either the application config
-`:endpoint` or the conn's endpoint using `Phoenix.ConnTest.dispatch/5`, with
-the params and with the method and action found in the form.
+Ultimately, the conn is dispatched to the conn's `private.phoenix_endpoint`
+using `Phoenix.ConnTest.dispatch/5`, with the params and with the method and
+action found in the form.

--- a/lib/test_dispatch_form.ex
+++ b/lib/test_dispatch_form.ex
@@ -22,9 +22,9 @@ defmodule TestDispatchForm do
 
   If an entity is given, the params will be prepended by this entity.
 
-  Ultimately, the conn is dispatched to the either the application config
-  `:endpoint` or the conn's endpoint using `Phoenix.ConnTest.dispatch/5`, with
-  the params and with the method and action found in the form.
+  Ultimately, the conn is dispatched to the conn's `private.phoenix_endpoint`
+  using `Phoenix.ConnTest.dispatch/5`, with the params and with the method and
+  action found in the form.
   """
   @spec dispatch_form_with(%Plug.Conn{}, %{required(atom()) => term()}, binary() | atom() | nil) ::
           %Plug.Conn{}
@@ -34,7 +34,6 @@ defmodule TestDispatchForm do
       when is_binary(entity_or_test_selector) or
              is_nil(entity_or_test_selector) or
              is_atom(entity_or_test_selector) do
-    endpoint = retrieve_endpoint(conn)
     {form, selector_type} = find_form(conn, entity_or_test_selector)
     selector_tuple = {selector_type, entity_or_test_selector}
 
@@ -43,14 +42,11 @@ defmodule TestDispatchForm do
     |> Enum.map(&input_to_tuple(&1, selector_tuple))
     |> update_input_values(attrs)
     |> prepend_entity(selector_tuple)
-    |> send_to_action(form, conn, endpoint)
+    |> send_to_action(form, conn)
   end
 
   def dispatch_form_with(conn, entity_or_test_selector, nil),
     do: dispatch_form_with(conn, %{}, entity_or_test_selector)
-
-  defp retrieve_endpoint(conn),
-    do: Application.get_env(:test_dispatch_form, :endpoint) || endpoint_module(conn)
 
   defp find_inputs(form, {:entity, _} = entity_tuple),
     do: find_input_fields(form, entity_tuple)
@@ -119,8 +115,9 @@ defmodule TestDispatchForm do
   end
 
   defp send_to_action(params, form, conn, endpoint) do
-    action = floki_attribute(form, "action")
+    endpoint = endpoint_module(conn)
     method = get_method_of_form(form)
+    action = floki_attribute(form, "action")
 
     dispatch(conn, endpoint, method, action, params)
   end


### PR DESCRIPTION
Introduce the function `retrieve_endpoint/1` to get the conn's endpoint to be used for
`Phoenix.ConnTest.dispatch/5`. This way it's possible to use the
`:endpoint` module attribute (also used by `Phoenix.ConnTest` and
`Phoenix.ChannelTest`) without adding an application config setting.

Also adjust the documentation and README.md to explain this.