### PR TITLE
Move Endpoint.start_link and build_conn to setup_all

### DIFF
--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -21,10 +21,12 @@ defmodule TestDispatchForm.ConnCase do
     end
   end
 
-  setup do
+  setup_all do
     TestDispatchFormTest.Endpoint.start_link()
-    Logger.disable(self())
-
     {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+
+  setup do
+    Logger.disable(self())
   end
 end


### PR DESCRIPTION
So it will run before all tests, instead of before each test separately.